### PR TITLE
Add initial support for v1.12.0 model

### DIFF
--- a/src/main/java/com/smallaswater/npc/command/base/BaseCommand.java
+++ b/src/main/java/com/smallaswater/npc/command/base/BaseCommand.java
@@ -6,6 +6,7 @@ import cn.nukkit.command.CommandSender;
 import cn.nukkit.command.data.CommandParameter;
 import com.smallaswater.npc.RsNPC;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -41,7 +42,11 @@ public abstract class BaseCommand extends Command {
                 if (subCommands.containsKey(subCommand)) {
                     BaseSubCommand command = this.subCommand.get(this.subCommands.get(subCommand));
                     if (command.canUser(sender)) {
-                        return command.execute(sender, s, args);
+                        try {
+                            return command.execute(sender, s, args);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
                     }else if (sender.isPlayer()) {
                         sender.sendMessage("你没有权限使用这个命令！");
                     }else {

--- a/src/main/java/com/smallaswater/npc/command/base/BaseSubCommand.java
+++ b/src/main/java/com/smallaswater/npc/command/base/BaseSubCommand.java
@@ -4,6 +4,8 @@ import cn.nukkit.command.CommandSender;
 import cn.nukkit.command.data.CommandParameter;
 import com.smallaswater.npc.RsNPC;
 
+import java.io.IOException;
+
 
 /**
  * @author SmallasWater
@@ -45,7 +47,7 @@ public abstract class BaseSubCommand {
      * @param label  label..
      * @return true if true
      */
-    public abstract boolean execute(CommandSender sender, String label, String[] args);
+    public abstract boolean execute(CommandSender sender, String label, String[] args) throws IOException;
 
     /**
      * 指令参数.

--- a/src/main/java/com/smallaswater/npc/command/sub/ReloadSubCommand.java
+++ b/src/main/java/com/smallaswater/npc/command/sub/ReloadSubCommand.java
@@ -4,6 +4,8 @@ import cn.nukkit.command.CommandSender;
 import cn.nukkit.command.data.CommandParameter;
 import com.smallaswater.npc.command.base.BaseSubCommand;
 
+import java.io.IOException;
+
 /**
  * @author LT_Name
  */
@@ -24,7 +26,7 @@ public class ReloadSubCommand extends BaseSubCommand {
     }
 
     @Override
-    public boolean execute(CommandSender sender, String label, String[] args) {
+    public boolean execute(CommandSender sender, String label, String[] args) throws IOException {
         this.rsNPC.reload();
         sender.sendMessage("§a§l已重载配置！");
         return true;


### PR DESCRIPTION
### Add initial support for v1.12.0 models
(**maybe it still needs to test more**)
If you have more v1.12.0 models, please help me test whether this method still works or not. thx!

### Performance
I've asked a friend to share a v1.12.0 model with me and tested it. Here is the performance:
![Minecraft 2022_7_11 14_28_21](https://user-images.githubusercontent.com/61799945/178204960-866ef56c-1f31-4bf6-a77a-b16ad96d306d.png)

### Others
**v1.16.0 models seem to be loaded in the same way, but I haven't got one to test it.**